### PR TITLE
Scale velocity advection backtrace + Reorder sim loop + Tuning fluid sim parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # simulation
 
+To see the simulation, visit https://anukritiw.github.io/WebGPU-FluidSim/
+
 ## Setup instructions
 
 1. Clone the repository
-```
+```bash
 git clone git@github.com:AnuKritiW/WebGPU-FluidSim.git
 cd WebGPU-FluidSim
 ```
@@ -11,16 +13,16 @@ cd WebGPU-FluidSim
 2. Install dependencies
 Make sure you have Node.js (v16 or later) installed.
 Then install the required packages:
-```
+```bash
 npm install
 ```
 
 3. Run the development server
-```
+```bash
 npm run dev
 ```
 You should see output like:
-```
+```bash
   VITE v6.2.5  ready in 648 ms
 
   ➜  Local:   http://localhost:5173/WebGPU-FluidSim/
@@ -41,3 +43,61 @@ You may need to enable the chrome://flags/#enable-unsafe-webgpu flag in Chrome:
   2. Search for “Unsafe WebGPU”
   3. Set it to Enabled
   4. Relaunch the browser
+
+## Deploying to GitHub Pages
+
+If you’ve cloned this repo and want to deploy it under **your own GitHub Pages link**, follow these steps:
+
+1. Install dependencies
+
+```bash
+npm install
+```
+
+2. Update `package.json`
+
+In `package.json`, update the homepage field to point to your GitHub Pages URL:
+```json
+"homepage": "https://<your-github-username>.github.io/<your-repo-name>/"
+```
+Replace `<your-github-username>` and `<your-repo-name>` with your GitHub username and repo name.
+
+This ensures asset paths are correct when hosted.
+
+3. Update `vite.config.js`
+
+In `vite.config.js`, set the base option to match your repo name:
+```js
+export default defineConfig({
+  base: '/<your-repo-name>/', // e.g. '/my-vite-app/'
+  // other config
+});
+```
+
+4. Build the project
+
+```bash
+npm run build
+```
+This generates the production build inside the `dist/` folder.
+
+1. Deploy to GitHub Pages
+
+Make sure you’re on the branch you want to deploy from (e.g., `main`), then run:
+```bash
+npm run deploy
+```
+
+This command pushes the `dist/` folder to a `gh-pages` branch in your repository.
+
+After a few minutes, your site will be live at:
+```php
+https://<your-github-username>.github.io/<your-repo-name>/
+```
+6. GitHub Pages settings (optional check)
+
+Make sure your repo’s GitHub Pages settings are set to deploy from the `gh-pages` branch.
+Go to:
+```
+Repo → Settings → Pages → Source → gh-pages branch
+```

--- a/src/gpu/buffers.ts
+++ b/src/gpu/buffers.ts
@@ -195,7 +195,7 @@ export function createBuffers(device: GPUDevice, gridSize: number, canvas: HTMLC
   const canvasSizeData = new Float32Array([canvas.width, canvas.height]);
   device.queue.writeBuffer(canvasSizeBuf, 0, canvasSizeData);
 
-  const vorticityStrengthData = new Float32Array([100.0, 0.0, 0.0, 0.0]);
+  const vorticityStrengthData = new Float32Array([500.0, 0.0, 0.0, 0.0]);
   device.queue.writeBuffer(vorticityStrengthBuf, 0, vorticityStrengthData);
 
   const viscosityData = new Float32Array([0.8, 0.0, 0.0, 0.0]);

--- a/src/gpu/buffers.ts
+++ b/src/gpu/buffers.ts
@@ -179,23 +179,23 @@ export function createBuffers(device: GPUDevice, gridSize: number, canvas: HTMLC
   const rdx = 1.0 / dx;
   const gridSizeData = new Float32Array([gridSize, gridSize, dx, rdx]);
   // TODO: adjust these parameters to see velocity injection more/less easily
-  const radiusData   = new Float32Array([12.0, 0.0, 0.0, 0.0]); // f32 aligned
+  const radiusData   = new Float32Array([2.0, 0.0, 0.0, 0.0]); // f32 aligned
   const strengthData = new Float32Array([0.25, 0.0, 0.0, 0.0]); // f32 aligned
 
   device.queue.writeBuffer(gridSizeBuf, 0, gridSizeData);
   device.queue.writeBuffer(radiusBuf, 0, radiusData);
   device.queue.writeBuffer(strengthBuf, 0, strengthData);
 
-  const decayData = new Float32Array([0.95, 0.0, 0.0, 0.0]); // f32 aligned
+  const decayData = new Float32Array([0.99, 0.0, 0.0, 0.0]); // f32 aligned
   device.queue.writeBuffer(decayBuf, 0, decayData);
 
-  const velDecayData = new Float32Array([0.95, 0.0, 0.0, 0.0]); // f32 aligned
+  const velDecayData = new Float32Array([1.0, 0.0, 0.0, 0.0]); // f32 aligned
   device.queue.writeBuffer(velDecayBuf, 0, velDecayData);
 
   const canvasSizeData = new Float32Array([canvas.width, canvas.height]);
   device.queue.writeBuffer(canvasSizeBuf, 0, canvasSizeData);
 
-  const vorticityStrengthData = new Float32Array([20.0, 0.0, 0.0, 0.0]);
+  const vorticityStrengthData = new Float32Array([100.0, 0.0, 0.0, 0.0]);
   device.queue.writeBuffer(vorticityStrengthBuf, 0, vorticityStrengthData);
 
   const viscosityData = new Float32Array([0.8, 0.0, 0.0, 0.0]);

--- a/src/input.ts
+++ b/src/input.ts
@@ -34,6 +34,32 @@ export class MouseHandler {
         (event.clientY - rect.top) / rect.height,
       ];
 
+      const numSteps = 20; // number of interpolation steps
+      for (let i = 1; i <= numSteps; i++) {
+        const t = i / (numSteps + 1);
+        const interpPos: [number, number] = [
+          lastPos[0] + (newPos[0] - lastPos[0]) * t,
+          lastPos[1] + (newPos[1] - lastPos[1]) * t
+        ];
+
+        const interpVel: [number, number] = [
+          interpPos[0] - lastPos[0],
+          interpPos[1] - lastPos[1]
+        ];
+
+        const boostedVel: [number, number] = [
+          interpVel[0] * 5.0, // same speed factor you already used
+          interpVel[1] * 5.0
+        ];
+
+        const data = new Float32Array([
+          interpPos[0], interpPos[1], // posX, posY
+          boostedVel[0], boostedVel[1] // velX, velY
+        ]);
+
+        device.queue.writeBuffer(mouseBuffer, 0, data);
+      }
+
       this.vel = [newPos[0] - lastPos[0], newPos[1] - lastPos[1]];
       this.pos = newPos;
       lastPos = newPos; // update last position for the next frame
@@ -47,9 +73,15 @@ export class MouseHandler {
   }
 
   updateGPUBuffer(device: GPUDevice, buffer: GPUBuffer) {
+    const speedFactor = 5.0;
+    const boostedVel: [number, number] = [
+      this.vel[0] * speedFactor,
+      this.vel[1] * speedFactor
+    ];
+
     const data = new Float32Array([
       this.pos[0], this.pos[1], // posX, posY
-      this.vel[0], this.vel[1]  // velX, velY
+      boostedVel[0], boostedVel[1]  // velX, velY
     ]);
 
     // write to GPU buffer

--- a/src/shaders/decay.wgsl
+++ b/src/shaders/decay.wgsl
@@ -20,7 +20,8 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
   let pos = vec2<f32>(f32(x), f32(y));
 
   let decayedDye = dye[index] * decayRate;
-  let threshold = vec3<f32>(0.01);
-  dye[index] = select(decayedDye, vec3<f32>(0.0), decayedDye < threshold);
+  // let threshold = vec3<f32>(0.01);
+  // dye[index] = select(decayedDye, vec3<f32>(0.0), decayedDye < threshold);
   // dye[index] = select(decayedDye, 0.0, decayedDye < 0.01);
+  dye[index] = decayedDye;
 }

--- a/src/shaders/injection.wgsl
+++ b/src/shaders/injection.wgsl
@@ -72,25 +72,18 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
   let mouseVel = uMouse.zw * uStrength * uGridSize.xy;
 
   // Define injection radius in grid units – within which injection occurs.
-  // let radius = 0.00025;
-  let radius = 20.0;
+  let radius = 2.0;
 
   // Gaussian weight for smoother injection
   let weight = gaussianWeight(pos, mousePos, mouseVel, radius);
 
-  // Add injection
-  // blends the new injection to any existing dye values within a clamped range
-  // clamped range avoids overflow
-  // dyeOut[index] = clamp(dye[index] * uDiffusion + injectionAmount * weight * uDeltaTime * 500.0, 0.0, 1.0);
-
-  // 🔵 Color logic — direction or time based hue
+  // Color logic — direction or time based hue
   let angle = atan2(mouseVel.y, mouseVel.x); // range (-π, π)
   let hue = fract(angle / (2.0 * 3.14159265)); // normalize to [0,1]
   let rgbColor = hsv2rgb(vec3<f32>(hue, 1.0, 1.0));
 
-  // 🟢 Inject and blend dye
+  // Inject and blend dye
   let current = dye[index];
   let injected = rgbColor * injectionAmount * weight * uDeltaTime * 500.0;
-  // dyeOut[index] = mix(current * uDiffusion, injected + current * uDiffusion, 0.5);
-  dyeOut[index] = clamp(injected + current * uDiffusion, vec3<f32>(0.0), vec3<f32>(1.0));
+  dyeOut[index] = clamp(injected + current * uDiffusion, vec3<f32>(0.0), vec3<f32>(10.0));
 }

--- a/src/shaders/velAdvection.wgsl
+++ b/src/shaders/velAdvection.wgsl
@@ -54,15 +54,9 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
   let v = velIn[index];
   
   // Compute the backtraced position (semi-Lagrangian method)
-  let backPos = pos - v * uDeltaTime;
+  // let backPos = pos - v * uDeltaTime;
+  let backPos = pos - v * uDeltaTime * uGridSize.w;
 
   // Bilinear Interpolation
-  let advectedVelocity =sampleVelocity(backPos);
-
-  let epsilon: f32 = 1e-4;
-  if (length(advectedVelocity) < epsilon) {
-    velOut[index] = vec2<f32>(0.0);
-  } else {
-    velOut[index] = advectedVelocity;
-  }
+  velOut[index] = sampleVelocity(backPos);
 }


### PR DESCRIPTION
This PR brings several key fixes and tuning adjustments to improve the behavior and visual quality of the WebGPU fluid simulation. 

Changes include:

1. **Simulation logic updates**
- Reordered simulation loop (moved velocity advection, projection, vorticity, boundaries into correct sequence).
- Scaled velocity advection backtrace by `uGridSize.w`

2. **Visual sharpening & swirl clarity**
- Increased vorticity confinement strength buffer for more prominent swirling.
- Disabled velocity decay by setting `velDecay` to `1.0` to avoid velocity loss over time.
- Reduced injection radius for sharper dye placement.

3.  **Cleanups & documentation**
- Removed decay threshold logic in some shaders.
- Updated README with deployment instructions.

Output:

![Screen Recording 2025-05-05 at 1 54 04 PM](https://github.com/user-attachments/assets/b8181afa-6924-4504-9056-6dc3e00c6f99)

